### PR TITLE
fix crashing caused by {{else match...} syntax

### DIFF
--- a/src/ast/visitors/text-extractor.js
+++ b/src/ast/visitors/text-extractor.js
@@ -218,10 +218,14 @@ class TextExtractorVisitor extends BaseVisitor {
 			}
 		} else if (ifTrue) {
 			this.markSource(loc.start, ifTrue.loc.start);
-			this.markSource(ifTrue.loc.end, loc.end);
+			if (!isLocSame(ifTrue.loc.end, loc.end)) {
+				this.markSource(ifTrue.loc.end, loc.end);
+			}
 		} else if (ifFalse) {
 			this.markSource(loc.start, ifFalse.loc.start);
-			this.markSource(ifFalse.loc.end, loc.end);
+			if (!isLocSame(ifFalse.loc.end, loc.end)) {
+				this.markSource(ifFalse.loc.end, loc.end);
+			}
 		} else {
 			throw new Error('Unexpected state');
 		}


### PR DESCRIPTION
Crashing was caused by {{else match...}} syntax.  If you'd like to test it, the edition theme has the problem (as do several other official themes)!