### PR TITLE
Add super update to handle new theme i18n build needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A toolkit to simplify theme translation.
 
 ## Features
 
-GT3 Can:
+GT3 can:
 
 * Detect and wrap untranslated strings in your theme
 * Report and update locales with extra/missing translations
+* Scan across multiple Ghost repositories (Casper, Source, all theme packages, Ghost core templates) and build a unified set of locale files and a `context.json`
 
 ## Getting Started
 
@@ -56,3 +57,109 @@ Runs "find" and "status" in `--fail` mode.
 Options:
 
  * All options supported by "find" and "status" are supported, though `--update` is ignored
+
+### `gt3 super-update`
+
+Scans all Ghost theme sources and updates the shared `theme-translations` locale files and `context.json`. Unlike the other commands, `super-update` does not take a theme path -- it reads from multiple sources defined in a config file.
+
+Options:
+
+  * `--config=<path>`: Path to config file (default: `super-update.config.json` in the gt3 root)
+  * `--verbose`: Show detailed per-key changes (which keys are added/removed)
+  * `--dry-run`: Show what would change without writing any files
+
+#### Sources scanned
+
+The command collects all `{{t "..."}}` translation strings from:
+
+* **Theme packages** in the local Themes repo (e.g. alto, bulletin, dawn, ...) -- excluding `_shared` and `theme-translations`
+* **Shared partials** (`_shared/partials`) in the Themes repo
+* **Casper** and **Source** themes (fetched from GitHub if not available locally)
+* **Ghost core tpl helpers** (`ghost/core/core/frontend/helpers/tpl/*.hbs`) -- pagination, content-cta, etc.
+* **private.hbs** (`ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs`)
+
+#### Output
+
+All output is written to the configured output directory (default: `Themes/packages/theme-translations/locales/`):
+
+* **`en.json`** (and any other locale files): keys are synced -- missing keys are added with empty values, keys no longer found in any source are removed.
+* **`context.json`**: maps each translation key to a description. Existing hand-written descriptions are preserved. New keys get auto-populated with a comma-separated list of source files where they appear (e.g. `"solo/post.hbs, ghost-tpl/pagination.hbs"`).
+
+#### Configuration
+
+The config file (`super-update.config.json`) defines where sources live:
+
+```json
+{
+  "themesRepo": "../Themes",
+  "output": "packages/theme-translations/locales",
+  "themePackages": {
+    "path": "packages",
+    "exclude": ["_shared", "theme-translations"]
+  },
+  "sharedPartials": "packages/_shared/partials",
+  "externalSources": [
+    {
+      "name": "casper",
+      "repo": "TryGhost/Casper",
+      "ref": "main",
+      "local": null
+    },
+    {
+      "name": "source",
+      "repo": "TryGhost/Source",
+      "ref": "main",
+      "local": null
+    },
+    {
+      "name": "ghost-tpl",
+      "repo": "TryGhost/Ghost",
+      "ref": "main",
+      "path": "ghost/core/core/frontend/helpers/tpl",
+      "local": null
+    },
+    {
+      "name": "ghost-private",
+      "repo": "TryGhost/Ghost",
+      "ref": "main",
+      "path": "ghost/core/core/frontend/apps/private-blogging/lib/views",
+      "files": ["private.hbs"],
+      "local": null
+    }
+  ]
+}
+```
+
+* **`themesRepo`**: Path to the local Themes repo (required -- it contains both sources and the output directory).
+* **`output`**: Directory within `themesRepo` where locale files are written.
+* **`themePackages`**: Which subdirectories of `themesRepo` to scan as individual themes.
+* **`sharedPartials`**: Path within `themesRepo` for shared partials.
+* **`externalSources`**: Sources that may not be available locally. Each entry has:
+  * `name`: Label used in context.json source tracking
+  * `repo`: GitHub `owner/repo` for fetching
+  * `ref`: Git ref to fetch (e.g. `main`)
+  * `path` (optional): Subdirectory within the repo
+  * `files` (optional): Allowlist of specific filenames to read
+  * `local` (optional): Local filesystem path. If set and the path exists, reads from disk instead of fetching from GitHub.
+
+#### Local development with all repos
+
+If you have the Ghost repo checked out locally, set `local` paths to avoid GitHub API calls:
+
+```json
+{
+  "name": "casper",
+  "repo": "TryGhost/Casper",
+  "ref": "main",
+  "local": "../Ghost/ghost/core/content/themes/casper"
+}
+```
+
+#### CI usage
+
+Leave `local` as `null` for external sources. Only the Themes repo needs to be checked out. Set the `GITHUB_TOKEN` environment variable to avoid API rate limits:
+
+```bash
+export GITHUB_TOKEN=ghp_...
+gt3 super-update
+```

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ All output is written to the configured output directory (default: `Themes/packa
 
 #### Configuration
 
-The config file (`super-update.config.json`) defines where sources live:
+The command looks for `super-update.config.json` in the current working directory first, then falls back to the bundled default in the gt3 package. All paths in the config are resolved relative to cwd.
 
 ```json
 {
-  "themesRepo": "../Themes",
+  "themesRepo": ".",
   "output": "packages/theme-translations/locales",
   "themePackages": {
     "path": "packages",
@@ -130,7 +130,7 @@ The config file (`super-update.config.json`) defines where sources live:
 }
 ```
 
-* **`themesRepo`**: Path to the local Themes repo (required -- it contains both sources and the output directory).
+* **`themesRepo`**: Path to the local Themes repo, relative to cwd (required -- it contains both sources and the output directory). Use `"."` when running from the Themes repo root.
 * **`output`**: Directory within `themesRepo` where locale files are written.
 * **`themePackages`**: Which subdirectories of `themesRepo` to scan as individual themes.
 * **`sharedPartials`**: Path within `themesRepo` for shared partials.

--- a/bin/gt3
+++ b/bin/gt3
@@ -40,7 +40,7 @@ Commands:
   ci <path-to-theme> : Runs "find" and "status" with --fail. Except for --update, all flags are passed to the commands.
 
   super-update : Scans all Ghost theme sources and updates the shared theme-translations locales and context.json.
-    --config=<path>: Path to config file (default: super-update.config.json in gt3 root)
+    --config=<path>: Path to config file (default: ./super-update.config.json, then bundled default)
     --verbose: Show detailed per-key changes
     --dry-run: Show what would change without writing files
 `.trimStart();
@@ -155,9 +155,15 @@ async function runSuperUpdate(args) {
 	const fs = require('node:fs/promises');
 	const {readSources} = require('../src/read-sources.js');
 
-	const configPath = args.config
-		? path.resolve(args.config)
-		: path.join(__dirname, '..', 'super-update.config.json');
+	let configPath;
+	if (args.config) {
+		configPath = path.resolve(args.config);
+	} else {
+		const cwdConfig = path.resolve('super-update.config.json');
+		const bundledConfig = path.join(__dirname, '..', 'super-update.config.json');
+		const cwdExists = await fs.stat(cwdConfig).then(() => true, () => false);
+		configPath = cwdExists ? cwdConfig : bundledConfig;
+	}
 
 	let configContents;
 	try {
@@ -168,9 +174,9 @@ async function runSuperUpdate(args) {
 	}
 
 	const config = JSON.parse(configContents);
-	const configDir = path.dirname(configPath);
+	const baseDir = process.cwd();
 
-	const sources = await readSources(config, configDir);
+	const sources = await readSources(config, baseDir);
 	const {superUpdateCommand} = require('../src/commands/super-update.js');
 	return superUpdateCommand(args, sources);
 }

--- a/bin/gt3
+++ b/bin/gt3
@@ -27,6 +27,7 @@ Commands:
     --fail: Exit with a non-zero exit code if any untranslated strings are found. Cannot be used with --update
     --json: Output the results in JSON format
     --verbose: Include file name and line number in the output
+    --packages: Treat each subdirectory of the given path as a separate theme
 
   status <path-to-theme> : Reports the translation status of each locale. Empty translations are ignored.
     --all: Report fully translated locales, not just those with untranslated strings
@@ -36,6 +37,7 @@ Commands:
     --strict: When used with --fail, also fail if any locales have extra strings
     --json: Output the results in JSON format
     --verbose: List the missing/extra strings for each locale
+    --packages: Treat each subdirectory of the given path as a separate theme
 
   ci <path-to-theme> : Runs "find" and "status" with --fail. Except for --update, all flags are passed to the commands.
 
@@ -53,9 +55,9 @@ function deferredCommand(importPath, exportName) {
 }
 
 /** @type {import('../src/commands/find.js').Flag[]} */
-const findFlags = ['update', 'fail', 'json', 'verbose', 'special-characters'];
+const findFlags = ['update', 'fail', 'json', 'verbose', 'special-characters', 'packages'];
 /** @type {import('../src/commands/status.js').Flag[]} */
-const statusFlags = ['all', 'verbose', 'json', 'fail', 'strict', 'update'];
+const statusFlags = ['all', 'verbose', 'json', 'fail', 'strict', 'update', 'packages'];
 /** @type {import('../src/commands/status.js').Parameter[]} */
 const statusParameters = ['base-lang'];
 
@@ -198,6 +200,33 @@ async function run() {
 	];
 
 	const Visitor = multiVisitor(visitors);
+
+	if (args.packages) {
+		const fs = require('node:fs/promises');
+		const path = require('node:path');
+
+		const entries = await fs.readdir(themePath, {withFileTypes: true});
+		const themePaths = entries
+			.filter((e) => e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules')
+			.map((e) => path.join(themePath, e.name));
+
+		if (themePaths.length === 0) {
+			console.error(`Error: No theme packages found in ${themePath}`);
+			exit(1);
+		}
+
+		let totalExitCode = 0;
+		for (const tp of themePaths) {
+			console.log(`\n=== ${path.basename(tp)} ===\n`);
+			const context = await readTheme(tp, Visitor);
+			const exitCode = await command(args, context);
+			totalExitCode += exitCode;
+		}
+
+		exit(totalExitCode);
+		return;
+	}
+
 	const context = await readTheme(themePath, Visitor);
 
 	const exitCode = await command(args, context);

--- a/bin/gt3
+++ b/bin/gt3
@@ -19,7 +19,7 @@ GT3 - The Ghost Theme Translation Toolkit
 
 Commands:
 
-  help : Print his help message
+  help : Print this help message
 
   find <path-to-theme> : Finds untranslated strings
     --special-characters: Consider strings of only special characters as untranslated
@@ -30,7 +30,7 @@ Commands:
 
   status <path-to-theme> : Reports the translation status of each locale. Empty translations are ignored.
     --all: Report fully translated locales, not just those with untranslated strings
-		--update: Automatically sync missing/extra strings in the locales
+    --update: Automatically sync missing/extra strings in the locales
     --base-locale=<locale>: Use this locale as the fully translated reference instead of reading the theme
     --fail: Exit with a non-zero exit code if any locales are missing strings
     --strict: When used with --fail, also fail if any locales have extra strings
@@ -38,6 +38,11 @@ Commands:
     --verbose: List the missing/extra strings for each locale
 
   ci <path-to-theme> : Runs "find" and "status" with --fail. Except for --update, all flags are passed to the commands.
+
+  super-update : Scans all Ghost theme sources and updates the shared theme-translations locales and context.json.
+    --config=<path>: Path to config file (default: super-update.config.json in gt3 root)
+    --verbose: Show detailed per-key changes
+    --dry-run: Show what would change without writing files
 `.trimStart();
 
 /**
@@ -53,6 +58,13 @@ const findFlags = ['update', 'fail', 'json', 'verbose', 'special-characters'];
 const statusFlags = ['all', 'verbose', 'json', 'fail', 'strict', 'update'];
 /** @type {import('../src/commands/status.js').Parameter[]} */
 const statusParameters = ['base-lang'];
+
+/** @type {import('../src/commands/super-update.js').Flag[]} */
+const superUpdateFlags = ['verbose', 'dry-run'];
+/** @type {import('../src/commands/super-update.js').Parameter[]} */
+const superUpdateParameters = ['config'];
+
+const STANDALONE_COMMANDS = new Set(['super-update', 'help']);
 
 /**
  * @satisfies {Record<string, CommandDefinition>}
@@ -87,37 +99,44 @@ const commands = {
 			return findResult + statusResult;
 		},
 	},
+	'super-update': {
+		flags: superUpdateFlags,
+		parameters: superUpdateParameters,
+		run: deferredCommand('../src/commands/super-update.js', 'superUpdateCommand'),
+	},
 };
 
-if (argv.length < 4) {
+const commandName = argv[2];
+
+if (!commandName) {
 	console.log(help);
+	exit(1);
+}
 
-	if (argv.length === 3 && argv[2] !== 'help') {
-		console.error('Error: Missing theme path');
-	}
-
+if (!STANDALONE_COMMANDS.has(commandName) && argv.length < 4) {
+	console.log(help);
+	console.error('Error: Missing theme path');
 	exit(1);
 }
 
 function parseCommand() {
-	const commandName = argv[2];
-	const themePath = argv[3];
-
 	if (commandName === 'help') {
 		commands.help.run();
 		exit(0);
 	}
 
 	/** @type {CommandDefinition} */
-	const command = commands[argv[2]];
+	const command = commands[commandName];
 	if (!command) {
-		console.error(`Unknown command: ${argv[2]}`);
+		console.error(`Unknown command: ${commandName}`);
 		console.error(help);
 		exit(1);
 	}
 
 	const minimist = require('minimist');
-	const args = minimist(argv.slice(3));
+	const isStandalone = STANDALONE_COMMANDS.has(commandName);
+	const args = minimist(argv.slice(isStandalone ? 3 : 3));
+	const themePath = isStandalone ? null : argv[3];
 	const flags = command.flags ?? [];
 	const parameters = command.parameters ?? [];
 
@@ -127,11 +146,44 @@ function parseCommand() {
 		args,
 		themePath,
 		command: command.run,
+		isStandalone,
 	};
 }
 
+async function runSuperUpdate(args) {
+	const path = require('node:path');
+	const fs = require('node:fs/promises');
+	const {readSources} = require('../src/read-sources.js');
+
+	const configPath = args.config
+		? path.resolve(args.config)
+		: path.join(__dirname, '..', 'super-update.config.json');
+
+	let configContents;
+	try {
+		configContents = await fs.readFile(configPath, 'utf8');
+	} catch {
+		console.error(`Error: Could not read config file: ${configPath}`);
+		exit(1);
+	}
+
+	const config = JSON.parse(configContents);
+	const configDir = path.dirname(configPath);
+
+	const sources = await readSources(config, configDir);
+	const {superUpdateCommand} = require('../src/commands/super-update.js');
+	return superUpdateCommand(args, sources);
+}
+
 async function run() {
-	const {themePath, args, command} = parseCommand();
+	const {themePath, args, command, isStandalone} = parseCommand();
+
+	if (isStandalone) {
+		const exitCode = await runSuperUpdate(args);
+		exit(exitCode ?? 0);
+		return;
+	}
+
 	const readTheme = require('../src/read-theme.js');
 	const {multiVisitor} = require('../src/ast/visitors/many.js');
 	const visitors = [

--- a/src/ast/visitors/base.js
+++ b/src/ast/visitors/base.js
@@ -60,16 +60,22 @@ class BaseVisitor extends Visitor {
 		super();
 		this.source = options.source;
 		this.fileName = options.fileName;
-
-		for (const method of VISITOR_METHODS) {
-			this[method] = wrappedVisitor(method, this[method]);
-		}
 	}
 
 	/**
 	 * @param {import('../types.js').Node} node
 	 */
 	enter(node) {
+		// Wrap visitor methods here (not in the constructor) so that subclass
+		// class-field initializers — which run after super() — are captured.
+		if (!this._methodsWrapped) {
+			for (const method of VISITOR_METHODS) {
+				this[method] = wrappedVisitor(method, this[method]);
+			}
+
+			this._methodsWrapped = true;
+		}
+
 		this.accept(node);
 		this.afterEnter();
 	}

--- a/src/ast/visitors/text-extractor.js
+++ b/src/ast/visitors/text-extractor.js
@@ -218,10 +218,14 @@ class TextExtractorVisitor extends BaseVisitor {
 			}
 		} else if (ifTrue) {
 			this.markSource(loc.start, ifTrue.loc.start);
-			this.markSource(ifTrue.loc.end, loc.end);
+			if (!isLocSame(ifTrue.loc.end, loc.end)) {
+				this.markSource(ifTrue.loc.end, loc.end);
+			}
 		} else if (ifFalse) {
 			this.markSource(loc.start, ifFalse.loc.start);
-			this.markSource(ifFalse.loc.end, loc.end);
+			if (!isLocSame(ifFalse.loc.end, loc.end)) {
+				this.markSource(ifFalse.loc.end, loc.end);
+			}
 		} else {
 			throw new Error('Unexpected state');
 		}

--- a/src/commands/super-update.js
+++ b/src/commands/super-update.js
@@ -154,8 +154,14 @@ async function superUpdateCommand(options, sources) {
 			delete store[key];
 		}
 
+		const sorted = Object.fromEntries(
+			Object.entries(store).sort(([a], [b]) => a.localeCompare(b)),
+		);
+		sorted[NEWLINE] = store[NEWLINE];
+		sorted[INDENTATION] = store[INDENTATION];
+
 		const filePath = path.join(outputPath, `${locale}.json`);
-		writePromises.push(fs.writeFile(filePath, stringifyJson(store)));
+		writePromises.push(fs.writeFile(filePath, stringifyJson(sorted)));
 		console.log(`\nWrote ${filePath}`);
 	}
 

--- a/src/commands/super-update.js
+++ b/src/commands/super-update.js
@@ -154,14 +154,8 @@ async function superUpdateCommand(options, sources) {
 			delete store[key];
 		}
 
-		const sorted = Object.fromEntries(
-			Object.entries(store).sort(([a], [b]) => a.localeCompare(b)),
-		);
-		sorted[NEWLINE] = store[NEWLINE];
-		sorted[INDENTATION] = store[INDENTATION];
-
 		const filePath = path.join(outputPath, `${locale}.json`);
-		writePromises.push(fs.writeFile(filePath, stringifyJson(sorted)));
+		writePromises.push(fs.writeFile(filePath, stringifyJson(store)));
 		console.log(`\nWrote ${filePath}`);
 	}
 

--- a/src/commands/super-update.js
+++ b/src/commands/super-update.js
@@ -153,7 +153,9 @@ async function superUpdateCommand(options, sources) {
 		for (const key of extra) {
 			delete store[key];
 		}
+	}
 
+	for (const [locale, store] of Object.entries(locales)) {
 		const filePath = path.join(outputPath, `${locale}.json`);
 		writePromises.push(fs.writeFile(filePath, stringifyJson(store)));
 		console.log(`\nWrote ${filePath}`);

--- a/src/commands/super-update.js
+++ b/src/commands/super-update.js
@@ -1,0 +1,175 @@
+// @ts-check
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const {parseJson, stringifyJson, NEWLINE, INDENTATION} = require('../util/inline-json.js');
+
+/**
+ * @typedef {'verbose' | 'dry-run'} Flag
+ * @typedef {'config'} Parameter
+ * @typedef {Record<Flag, boolean> & Record<Parameter, string>} Options
+ * @typedef {import('../read-sources.js').SourcesResult} SourcesResult
+ */
+
+/**
+ * Read context.json from the output directory if it exists.
+ * @param {string} outputPath
+ * @returns {Promise<Record<string, string> | null>}
+ */
+async function readContext(outputPath) {
+	const contextPath = path.join(outputPath, 'context.json');
+	try {
+		const contents = await fs.readFile(contextPath, 'utf8');
+		return parseJson(contents);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Build a fresh context object, preserving existing hand-written descriptions.
+ * @param {Map<string, Set<string>>} keySources
+ * @param {Record<string, string> | null} existingContext
+ * @returns {Record<string, string>}
+ */
+function buildContext(keySources, existingContext) {
+	/** @type {Record<string, string>} */
+	const context = {};
+
+	const sortedKeys = [...keySources.keys()].sort((a, b) => a.localeCompare(b));
+
+	for (const key of sortedKeys) {
+		const existing = existingContext?.[key];
+		if (existing && existing.length > 0) {
+			context[key] = existing;
+		} else {
+			const sources = keySources.get(key);
+			context[key] = sources ? [...sources].sort().join(', ') : '';
+		}
+	}
+
+	return context;
+}
+
+/**
+ * @param {Options} options
+ * @param {SourcesResult} sources
+ */
+async function superUpdateCommand(options, sources) {
+	const {verbose, 'dry-run': dryRun} = options;
+	const {translatedStrings, keySources, locales, outputPath} = sources;
+
+	const expectedKeys = new Set(translatedStrings.keys());
+
+	// --- Analyze locale changes ---
+	/** @type {Record<string, {missing: string[], extra: string[]}>} */
+	const localeChanges = {};
+	let totalMissing = 0;
+	let totalExtra = 0;
+
+	for (const [locale, strings] of Object.entries(locales)) {
+		const existingKeys = new Set(Object.keys(strings));
+		const missing = [...expectedKeys].filter((k) => !existingKeys.has(k));
+		const extra = [...existingKeys].filter((k) => !expectedKeys.has(k));
+
+		if (missing.length > 0 || extra.length > 0) {
+			localeChanges[locale] = {missing, extra};
+			totalMissing += missing.length;
+			totalExtra += extra.length;
+		}
+	}
+
+	// If no locale files exist yet, create en.json
+	if (Object.keys(locales).length === 0) {
+		const missing = [...expectedKeys];
+		localeChanges.en = {missing, extra: []};
+		locales.en = {};
+		locales.en[NEWLINE] = '\n';
+		locales.en[INDENTATION] = '    ';
+		totalMissing += missing.length;
+	}
+
+	// --- Analyze context changes ---
+	const existingContext = await readContext(outputPath);
+	const newContext = buildContext(keySources, existingContext);
+	const contextAdded = Object.keys(newContext).filter((k) => !existingContext?.[k]);
+	const contextRemoved = existingContext
+		? Object.keys(existingContext).filter((k) => !(k in newContext) && typeof k === 'string')
+		: [];
+
+	// --- Summary ---
+	console.log('\n=== Super Update Summary ===');
+	console.log(`Total translation keys found: ${expectedKeys.size}`);
+	console.log(`Locale files: ${Object.keys(locales).length}`);
+
+	if (totalMissing > 0 || totalExtra > 0) {
+		console.log(`\nLocale changes:`);
+		for (const [locale, {missing, extra}] of Object.entries(localeChanges)) {
+			console.log(`  ${locale}.json: +${missing.length} missing, -${extra.length} extra`);
+			if (verbose) {
+				for (const key of missing) {
+					console.log(`    + "${key}"`);
+				}
+
+				for (const key of extra) {
+					console.log(`    - "${key}"`);
+				}
+			}
+		}
+	} else {
+		console.log('\nAll locale files are up to date.');
+	}
+
+	if (contextAdded.length > 0 || contextRemoved.length > 0) {
+		console.log(`\nContext changes: +${contextAdded.length} added, -${contextRemoved.length} removed`);
+		if (verbose) {
+			for (const key of contextAdded) {
+				console.log(`  + "${key}": "${newContext[key]}"`);
+			}
+
+			for (const key of contextRemoved) {
+				console.log(`  - "${key}"`);
+			}
+		}
+	} else {
+		console.log('\ncontext.json is up to date.');
+	}
+
+	if (dryRun) {
+		console.log('\n(dry run -- no files written)');
+		return 0;
+	}
+
+	// --- Write files ---
+	await fs.mkdir(outputPath, {recursive: true});
+	const writePromises = [];
+
+	for (const [locale, {missing, extra}] of Object.entries(localeChanges)) {
+		const store = locales[locale];
+
+		for (const key of missing) {
+			store[key] = '';
+		}
+
+		for (const key of extra) {
+			delete store[key];
+		}
+
+		const filePath = path.join(outputPath, `${locale}.json`);
+		writePromises.push(fs.writeFile(filePath, stringifyJson(store)));
+		console.log(`\nWrote ${filePath}`);
+	}
+
+	// Write context.json
+	const contextWithAnnotations = Object.assign(newContext, {
+		[NEWLINE]: '\n',
+		[INDENTATION]: '    ',
+	});
+	const contextPath = path.join(outputPath, 'context.json');
+	writePromises.push(fs.writeFile(contextPath, stringifyJson(contextWithAnnotations)));
+	console.log(`Wrote ${contextPath}`);
+
+	await Promise.all(writePromises);
+	return 0;
+}
+
+module.exports.superUpdateCommand = superUpdateCommand;

--- a/src/read-sources.js
+++ b/src/read-sources.js
@@ -1,0 +1,230 @@
+// @ts-check
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const {parseWithoutProcessing} = require('handlebars');
+const {TranslatedStringsVisitor} = require('./ast/visitors/translated-strings.js');
+const {fetchHbsFiles} = require('./util/github-fetcher.js');
+const {getLocales} = require('./util/read-locales.js');
+
+/**
+ * @typedef {import('./ast/visitors/translated-strings.js').TranslatedString} TranslatedString
+ *
+ * @typedef {{
+ *   themesRepo: string;
+ *   output: string;
+ *   themePackages: {path: string; exclude: string[]};
+ *   sharedPartials: string;
+ *   externalSources: Array<{
+ *     name: string;
+ *     repo: string;
+ *     ref: string;
+ *     path?: string;
+ *     local?: string | null;
+ *     files?: string[];
+ *   }>;
+ * }} SuperUpdateConfig
+ *
+ * @typedef {{
+ *   translatedStrings: Map<string, TranslatedString>;
+ *   keySources: Map<string, Set<string>>;
+ *   locales: Record<string, Record<string, string>>;
+ *   outputPath: string;
+ * }} SourcesResult
+ */
+
+/**
+ * Glob for .hbs files in a local directory (non-recursive into .gitignored dirs).
+ * @param {string} dirPath
+ * @returns {Promise<Array<{path: string, contents: string}>>}
+ */
+async function getLocalHbsFiles(dirPath) {
+	const results = [];
+	const promises = [];
+
+	for await (const file of fs.glob(`${dirPath}/**/*.hbs`, {withFileTypes: true})) {
+		if (file.isDirectory()) {
+			continue;
+		}
+
+		const filePath = path.join(file.parentPath, file.name);
+		const relativePath = path.relative(dirPath, filePath);
+
+		promises.push(
+			fs.readFile(filePath, 'utf8').then((contents) => {
+				results.push({path: relativePath, contents});
+			}),
+		);
+	}
+
+	await Promise.all(promises);
+	return results;
+}
+
+/**
+ * @param {Array<{path: string, contents: string}>} files
+ * @param {string} sourceName
+ * @param {ReturnType<typeof TranslatedStringsVisitor.createContext>} visitorContext
+ * @param {Map<string, Set<string>>} keySources
+ */
+function processFiles(files, sourceName, visitorContext, keySources) {
+	for (const file of files) {
+		const fileLabel = `${sourceName}/${file.path}`;
+
+		const locationCountsBefore = new Map();
+		for (const [key, data] of visitorContext.translatedStrings) {
+			locationCountsBefore.set(key, data.locations.length);
+		}
+
+		let ast;
+		try {
+			ast = parseWithoutProcessing(file.contents, {srcName: file.path});
+		} catch {
+			continue;
+		}
+
+		const visitor = new TranslatedStringsVisitor(
+			{source: file.contents, fileName: file.path},
+			visitorContext,
+		);
+		visitor.enter(ast);
+
+		for (const [key, data] of visitorContext.translatedStrings) {
+			const prevCount = locationCountsBefore.get(key) ?? 0;
+			if (data.locations.length > prevCount) {
+				if (!keySources.has(key)) {
+					keySources.set(key, new Set());
+				}
+
+				keySources.get(key).add(fileLabel);
+			}
+		}
+	}
+}
+
+/**
+ * Scan a single local theme directory for .hbs files and process them.
+ * @param {string} themePath
+ * @param {string} sourceName
+ * @param {ReturnType<typeof TranslatedStringsVisitor.createContext>} visitorContext
+ * @param {Map<string, Set<string>>} keySources
+ */
+async function scanLocalTheme(themePath, sourceName, visitorContext, keySources) {
+	const exists = await fs.stat(themePath).then(
+		(s) => s.isDirectory(),
+		() => false,
+	);
+	if (!exists) {
+		console.error(`Warning: skipping ${sourceName} - directory not found: ${themePath}`);
+		return;
+	}
+
+	const files = await getLocalHbsFiles(themePath);
+	processFiles(files, sourceName, visitorContext, keySources);
+}
+
+/**
+ * List theme package directories in the Themes repo, excluding configured dirs.
+ * @param {string} packagesDir
+ * @param {string[]} exclude
+ * @returns {Promise<Array<{name: string, path: string}>>}
+ */
+async function listThemePackages(packagesDir, exclude) {
+	const entries = await fs.readdir(packagesDir, {withFileTypes: true});
+	return entries
+		.filter((e) => e.isDirectory() && !exclude.includes(e.name) && !e.name.startsWith('.'))
+		.map((e) => ({name: e.name, path: path.join(packagesDir, e.name)}));
+}
+
+/**
+ * Resolve an external source: use local path if available, otherwise fetch from GitHub.
+ * @param {SuperUpdateConfig['externalSources'][number]} source
+ * @param {string} configDir - directory containing the config file, for resolving relative local paths
+ * @returns {Promise<Array<{path: string, contents: string}>>}
+ */
+async function resolveExternalSource(source, configDir) {
+	if (source.local) {
+		const localPath = path.resolve(configDir, source.local);
+		const exists = await fs.stat(localPath).then(
+			(s) => s.isDirectory() || s.isFile(),
+			() => false,
+		);
+
+		if (exists) {
+			console.log(`  ${source.name}: reading from local path ${localPath}`);
+			return getLocalHbsFiles(localPath);
+		}
+
+		console.log(`  ${source.name}: local path not found, falling back to GitHub`);
+	}
+
+	console.log(`  ${source.name}: fetching from GitHub ${source.repo}${source.path ? `/${source.path}` : ''}`);
+	return fetchHbsFiles({
+		repo: source.repo,
+		ref: source.ref,
+		path: source.path,
+		files: source.files,
+	});
+}
+
+/**
+ * Read all sources defined in the config and return merged translation data.
+ * @param {SuperUpdateConfig} config
+ * @param {string} configDir - directory containing the config file
+ * @returns {Promise<SourcesResult>}
+ */
+async function readSources(config, configDir) {
+	const themesRepoPath = path.resolve(configDir, config.themesRepo);
+	const outputPath = path.resolve(themesRepoPath, config.output);
+
+	const visitorContext = TranslatedStringsVisitor.createContext();
+	/** @type {Map<string, Set<string>>} */
+	const keySources = new Map();
+
+	// Track keys before each source to compute per-source additions
+	const keysBefore = () => new Set(visitorContext.translatedStrings.keys());
+
+	// 1. Scan theme packages from the local Themes repo
+	console.log('Scanning theme packages...');
+	const packagesDir = path.resolve(themesRepoPath, config.themePackages.path);
+	const packages = await listThemePackages(packagesDir, config.themePackages.exclude);
+
+	for (const pkg of packages) {
+		const before = keysBefore();
+		await scanLocalTheme(pkg.path, pkg.name, visitorContext, keySources);
+		const after = new Set(visitorContext.translatedStrings.keys());
+		const newKeys = [...after].filter((k) => !before.has(k));
+		if (newKeys.length > 0) {
+			console.log(`  ${pkg.name}: ${newKeys.length} new key(s)`);
+		}
+	}
+
+	// 2. Scan shared partials
+	console.log('Scanning shared partials...');
+	const sharedPartialsPath = path.resolve(themesRepoPath, config.sharedPartials);
+	await scanLocalTheme(sharedPartialsPath, '_shared', visitorContext, keySources);
+
+	// 3. Scan external sources (local or GitHub)
+	console.log('Scanning external sources...');
+	for (const source of config.externalSources) {
+		const before = keysBefore();
+		const files = await resolveExternalSource(source, configDir);
+		processFiles(files, source.name, visitorContext, keySources);
+		const after = new Set(visitorContext.translatedStrings.keys());
+		const newKeys = [...after].filter((k) => !before.has(k));
+		if (newKeys.length > 0) {
+			console.log(`    ${newKeys.length} new key(s)`);
+		}
+	}
+
+	// 4. Read existing locales from the output directory
+	const locales = await getLocales(outputPath);
+
+	return {
+		translatedStrings: visitorContext.translatedStrings,
+		keySources,
+		locales,
+		outputPath,
+	};
+}
+
+module.exports.readSources = readSources;

--- a/src/read-sources.js
+++ b/src/read-sources.js
@@ -138,12 +138,12 @@ async function listThemePackages(packagesDir, exclude) {
 /**
  * Resolve an external source: use local path if available, otherwise fetch from GitHub.
  * @param {SuperUpdateConfig['externalSources'][number]} source
- * @param {string} configDir - directory containing the config file, for resolving relative local paths
+ * @param {string} baseDir - base directory for resolving relative paths (typically cwd)
  * @returns {Promise<Array<{path: string, contents: string}>>}
  */
-async function resolveExternalSource(source, configDir) {
+async function resolveExternalSource(source, baseDir) {
 	if (source.local) {
-		const localPath = path.resolve(configDir, source.local);
+		const localPath = path.resolve(baseDir, source.local);
 		const exists = await fs.stat(localPath).then(
 			(s) => s.isDirectory() || s.isFile(),
 			() => false,
@@ -169,11 +169,11 @@ async function resolveExternalSource(source, configDir) {
 /**
  * Read all sources defined in the config and return merged translation data.
  * @param {SuperUpdateConfig} config
- * @param {string} configDir - directory containing the config file
+ * @param {string} baseDir - base directory for resolving relative paths (typically cwd)
  * @returns {Promise<SourcesResult>}
  */
-async function readSources(config, configDir) {
-	const themesRepoPath = path.resolve(configDir, config.themesRepo);
+async function readSources(config, baseDir) {
+	const themesRepoPath = path.resolve(baseDir, config.themesRepo);
 	const outputPath = path.resolve(themesRepoPath, config.output);
 
 	const visitorContext = TranslatedStringsVisitor.createContext();
@@ -207,7 +207,7 @@ async function readSources(config, configDir) {
 	console.log('Scanning external sources...');
 	for (const source of config.externalSources) {
 		const before = keysBefore();
-		const files = await resolveExternalSource(source, configDir);
+		const files = await resolveExternalSource(source, baseDir);
 		processFiles(files, source.name, visitorContext, keySources);
 		const after = new Set(visitorContext.translatedStrings.keys());
 		const newKeys = [...after].filter((k) => !before.has(k));

--- a/src/read-theme.js
+++ b/src/read-theme.js
@@ -2,7 +2,7 @@
 const fs = require('node:fs/promises');
 const path = require('node:path');
 const {parseWithoutProcessing} = require('handlebars');
-const {parseJson} = require('./util/inline-json.js');
+const {getLocales} = require('./util/read-locales.js');
 
 /**
  * @typedef {import('./types.js').ParsedTheme} ParsedTheme
@@ -66,33 +66,8 @@ async function getHandlebarsFiles(themePath, ignore) {
 /**
  * @param {string} themePath
  */
-async function getLocales(themePath) {
-	const localesPath = path.join(themePath, 'locales');
-	/** @type {Record<string, Record<string, string>>} */
-	const locales = {};
-
-	if (
-		!(await fs.stat(localesPath).then(
-			(stat) => stat.isDirectory(),
-			() => false,
-		))
-	) {
-		return locales;
-	}
-
-	const promises = [];
-
-	for await (const file of fs.glob(`${localesPath}/*.json`)) {
-		const locale = path.parse(file).name;
-		promises.push(
-			fs.readFile(file, 'utf8').then((contents) => {
-				locales[locale] = parseJson(contents);
-			}),
-		);
-	}
-
-	await Promise.all(promises);
-	return locales;
+function getThemeLocales(themePath) {
+	return getLocales(path.join(themePath, 'locales'));
 }
 
 /**
@@ -102,7 +77,7 @@ async function getLocales(themePath) {
  */
 module.exports = async function readTheme(themePath, Visitor) {
 	const resolvedThemePath = path.join(themePath, '.');
-	const locales = getLocales(resolvedThemePath);
+	const locales = getThemeLocales(resolvedThemePath);
 	const ignore = await readGitIgnore(resolvedThemePath);
 	const files = await getHandlebarsFiles(resolvedThemePath, ignore);
 	const visitorContext = Visitor.createContext();

--- a/src/util/github-fetcher.js
+++ b/src/util/github-fetcher.js
@@ -1,7 +1,13 @@
 // @ts-check
 const {env} = require('node:process');
+const {setTimeout: sleep} = require('node:timers/promises');
 
 const GITHUB_API = 'https://api.github.com';
+const UNAUTHENTICATED_DELAY_MS = 800;
+
+function isAuthenticated() {
+	return Boolean(env.GITHUB_TOKEN);
+}
 
 function getHeaders() {
 	/** @type {Record<string, string>} */
@@ -28,64 +34,56 @@ async function githubGet(url) {
 }
 
 /**
- * Fetch the contents of a single file from GitHub.
- * @param {string} repo - e.g. "TryGhost/Casper"
- * @param {string} ref - e.g. "main"
- * @param {string} filePath - path within the repo
+ * Download raw file content from GitHub (does not count against API rate limit).
+ * @param {string} repo
+ * @param {string} ref
+ * @param {string} filePath
  * @returns {Promise<string>}
  */
-async function fetchFileContent(repo, ref, filePath) {
-	const url = `${GITHUB_API}/repos/${repo}/contents/${filePath}?ref=${ref}`;
-	const data = await githubGet(url);
-	if (data.encoding !== 'base64') {
-		throw new Error(`Unexpected encoding "${data.encoding}" for ${repo}/${filePath}`);
+async function fetchRawContent(repo, ref, filePath) {
+	const url = `https://raw.githubusercontent.com/${repo}/${ref}/${filePath}`;
+	const response = await fetch(url, {headers: {'User-Agent': 'gt3'}});
+	if (!response.ok) {
+		throw new Error(`GitHub raw ${response.status} for ${url}`);
 	}
 
-	return Buffer.from(data.content, 'base64').toString('utf8');
+	return response.text();
 }
 
 /**
- * List directory entries from the GitHub Contents API (non-recursive, one level).
+ * Use the Git Trees API to list all files in a repo (or subtree) in a single request.
+ * Returns only .hbs file paths.
  * @param {string} repo
  * @param {string} ref
- * @param {string} dirPath
- * @returns {Promise<Array<{name: string, path: string, type: string}>>}
- */
-async function listDirectory(repo, ref, dirPath) {
-	const url = `${GITHUB_API}/repos/${repo}/contents/${dirPath}?ref=${ref}`;
-	const data = await githubGet(url);
-	if (!Array.isArray(data)) {
-		throw new Error(`Expected directory listing for ${repo}/${dirPath}, got a single file`);
-	}
-
-	return data;
-}
-
-/**
- * Recursively collect all .hbs file paths under a directory in a GitHub repo.
- * @param {string} repo
- * @param {string} ref
- * @param {string} dirPath
+ * @param {string} [subpath]
  * @returns {Promise<string[]>}
  */
-async function listHbsFilesRecursive(repo, ref, dirPath) {
-	const entries = await listDirectory(repo, ref, dirPath);
-	/** @type {string[]} */
-	const results = [];
-	/** @type {Promise<string[]>[]} */
-	const subdirPromises = [];
-
-	for (const entry of entries) {
-		if (entry.type === 'file' && entry.name.endsWith('.hbs')) {
-			results.push(entry.path);
-		} else if (entry.type === 'dir') {
-			subdirPromises.push(listHbsFilesRecursive(repo, ref, entry.path));
-		}
+async function listHbsFilesViaTree(repo, ref, subpath) {
+	if (!isAuthenticated()) {
+		await sleep(UNAUTHENTICATED_DELAY_MS);
 	}
 
-	const subdirResults = await Promise.all(subdirPromises);
-	for (const files of subdirResults) {
-		results.push(...files);
+	const url = `${GITHUB_API}/repos/${repo}/git/trees/${ref}?recursive=1`;
+	const data = await githubGet(url);
+
+	/** @type {string[]} */
+	const results = [];
+	const prefix = subpath ? `${subpath}/` : '';
+
+	for (const item of data.tree) {
+		if (item.type !== 'blob') {
+			continue;
+		}
+
+		if (!item.path.endsWith('.hbs')) {
+			continue;
+		}
+
+		if (subpath && !item.path.startsWith(prefix)) {
+			continue;
+		}
+
+		results.push(item.path);
 	}
 
 	return results;
@@ -93,6 +91,8 @@ async function listHbsFilesRecursive(repo, ref, dirPath) {
 
 /**
  * Fetch all .hbs files from a GitHub repo (or a subpath within it).
+ * Uses the Git Trees API (1 request) to list files, then raw.githubusercontent.com
+ * to download content (not rate-limited).
  *
  * @param {object} options
  * @param {string} options.repo - e.g. "TryGhost/Casper"
@@ -103,27 +103,44 @@ async function listHbsFilesRecursive(repo, ref, dirPath) {
  */
 async function fetchHbsFiles({repo, ref, path: subpath, files: allowlist}) {
 	const basePath = subpath || '';
+	const throttle = !isAuthenticated();
+
+	/** @type {Array<{repoPath: string, outputPath: string}>} */
+	let filesToFetch;
 
 	if (allowlist && allowlist.length > 0) {
-		const promises = allowlist
+		filesToFetch = allowlist
 			.filter((f) => f.endsWith('.hbs'))
-			.map(async (fileName) => {
-				const filePath = basePath ? `${basePath}/${fileName}` : fileName;
-				const contents = await fetchFileContent(repo, ref, filePath);
-				return {path: fileName, contents};
-			});
-		return Promise.all(promises);
+			.map((fileName) => ({
+				repoPath: basePath ? `${basePath}/${fileName}` : fileName,
+				outputPath: fileName,
+			}));
+	} else {
+		const hbsPaths = await listHbsFilesViaTree(repo, ref, basePath);
+		filesToFetch = hbsPaths.map((filePath) => ({
+			repoPath: filePath,
+			outputPath: basePath ? filePath.slice(basePath.length + 1) : filePath,
+		}));
 	}
 
-	const hbsPaths = await listHbsFilesRecursive(repo, ref, basePath);
+	if (!throttle) {
+		return Promise.all(
+			filesToFetch.map(async ({repoPath, outputPath}) => {
+				const contents = await fetchRawContent(repo, ref, repoPath);
+				return {path: outputPath, contents};
+			}),
+		);
+	}
 
-	const promises = hbsPaths.map(async (filePath) => {
-		const contents = await fetchFileContent(repo, ref, filePath);
-		const relativePath = basePath ? filePath.slice(basePath.length + 1) : filePath;
-		return {path: relativePath, contents};
-	});
+	/** @type {Array<{path: string, contents: string}>} */
+	const results = [];
+	for (const {repoPath, outputPath} of filesToFetch) {
+		const contents = await fetchRawContent(repo, ref, repoPath);
+		results.push({path: outputPath, contents});
+		await sleep(UNAUTHENTICATED_DELAY_MS);
+	}
 
-	return Promise.all(promises);
+	return results;
 }
 
 module.exports.fetchHbsFiles = fetchHbsFiles;

--- a/src/util/github-fetcher.js
+++ b/src/util/github-fetcher.js
@@ -1,0 +1,129 @@
+// @ts-check
+const {env} = require('node:process');
+
+const GITHUB_API = 'https://api.github.com';
+
+function getHeaders() {
+	/** @type {Record<string, string>} */
+	const headers = {Accept: 'application/vnd.github.v3+json', 'User-Agent': 'gt3'};
+	if (env.GITHUB_TOKEN) {
+		headers.Authorization = `token ${env.GITHUB_TOKEN}`;
+	}
+
+	return headers;
+}
+
+/**
+ * @param {string} url
+ * @returns {Promise<any>}
+ */
+async function githubGet(url) {
+	const response = await fetch(url, {headers: getHeaders()});
+	if (!response.ok) {
+		const body = await response.text().catch(() => '');
+		throw new Error(`GitHub API ${response.status} for ${url}: ${body}`);
+	}
+
+	return response.json();
+}
+
+/**
+ * Fetch the contents of a single file from GitHub.
+ * @param {string} repo - e.g. "TryGhost/Casper"
+ * @param {string} ref - e.g. "main"
+ * @param {string} filePath - path within the repo
+ * @returns {Promise<string>}
+ */
+async function fetchFileContent(repo, ref, filePath) {
+	const url = `${GITHUB_API}/repos/${repo}/contents/${filePath}?ref=${ref}`;
+	const data = await githubGet(url);
+	if (data.encoding !== 'base64') {
+		throw new Error(`Unexpected encoding "${data.encoding}" for ${repo}/${filePath}`);
+	}
+
+	return Buffer.from(data.content, 'base64').toString('utf8');
+}
+
+/**
+ * List directory entries from the GitHub Contents API (non-recursive, one level).
+ * @param {string} repo
+ * @param {string} ref
+ * @param {string} dirPath
+ * @returns {Promise<Array<{name: string, path: string, type: string}>>}
+ */
+async function listDirectory(repo, ref, dirPath) {
+	const url = `${GITHUB_API}/repos/${repo}/contents/${dirPath}?ref=${ref}`;
+	const data = await githubGet(url);
+	if (!Array.isArray(data)) {
+		throw new Error(`Expected directory listing for ${repo}/${dirPath}, got a single file`);
+	}
+
+	return data;
+}
+
+/**
+ * Recursively collect all .hbs file paths under a directory in a GitHub repo.
+ * @param {string} repo
+ * @param {string} ref
+ * @param {string} dirPath
+ * @returns {Promise<string[]>}
+ */
+async function listHbsFilesRecursive(repo, ref, dirPath) {
+	const entries = await listDirectory(repo, ref, dirPath);
+	/** @type {string[]} */
+	const results = [];
+	/** @type {Promise<string[]>[]} */
+	const subdirPromises = [];
+
+	for (const entry of entries) {
+		if (entry.type === 'file' && entry.name.endsWith('.hbs')) {
+			results.push(entry.path);
+		} else if (entry.type === 'dir') {
+			subdirPromises.push(listHbsFilesRecursive(repo, ref, entry.path));
+		}
+	}
+
+	const subdirResults = await Promise.all(subdirPromises);
+	for (const files of subdirResults) {
+		results.push(...files);
+	}
+
+	return results;
+}
+
+/**
+ * Fetch all .hbs files from a GitHub repo (or a subpath within it).
+ *
+ * @param {object} options
+ * @param {string} options.repo - e.g. "TryGhost/Casper"
+ * @param {string} options.ref - e.g. "main"
+ * @param {string} [options.path] - optional subpath within the repo
+ * @param {string[]} [options.files] - optional allowlist of specific filenames
+ * @returns {Promise<Array<{path: string, contents: string}>>}
+ */
+async function fetchHbsFiles({repo, ref, path: subpath, files: allowlist}) {
+	const basePath = subpath || '';
+
+	if (allowlist && allowlist.length > 0) {
+		const promises = allowlist
+			.filter((f) => f.endsWith('.hbs'))
+			.map(async (fileName) => {
+				const filePath = basePath ? `${basePath}/${fileName}` : fileName;
+				const contents = await fetchFileContent(repo, ref, filePath);
+				return {path: fileName, contents};
+			});
+		return Promise.all(promises);
+	}
+
+	const hbsPaths = await listHbsFilesRecursive(repo, ref, basePath);
+
+	const promises = hbsPaths.map(async (filePath) => {
+		const contents = await fetchFileContent(repo, ref, filePath);
+		const relativePath = basePath ? filePath.slice(basePath.length + 1) : filePath;
+		return {path: relativePath, contents};
+	});
+
+	return Promise.all(promises);
+}
+
+module.exports.fetchHbsFiles = fetchHbsFiles;

--- a/src/util/inline-json.js
+++ b/src/util/inline-json.js
@@ -59,7 +59,8 @@ function stringifyJson(object) {
 	assertHasAnnotations(object);
 	const newline = object[NEWLINE];
 	const indentation = object[INDENTATION];
-	const serialized = JSON.stringify(object, null, indentation);
+	const sortedKeys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+	const serialized = JSON.stringify(object, sortedKeys, indentation);
 
 	return newline === '\n' ? serialized : serialized.replaceAll('\n', newline) + newline;
 }

--- a/src/util/read-locales.js
+++ b/src/util/read-locales.js
@@ -1,0 +1,42 @@
+// @ts-check
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const {parseJson} = require('./inline-json.js');
+
+/**
+ * @param {string} localesPath - absolute path to a locales directory
+ * @returns {Promise<Record<string, Record<string, string>>>}
+ */
+async function getLocales(localesPath) {
+	/** @type {Record<string, Record<string, string>>} */
+	const locales = {};
+
+	if (
+		!(await fs.stat(localesPath).then(
+			(stat) => stat.isDirectory(),
+			() => false,
+		))
+	) {
+		return locales;
+	}
+
+	const promises = [];
+
+	for await (const file of fs.glob(`${localesPath}/*.json`)) {
+		const name = path.parse(file).name;
+		if (name === 'context') {
+			continue;
+		}
+
+		promises.push(
+			fs.readFile(file, 'utf8').then((contents) => {
+				locales[name] = parseJson(contents);
+			}),
+		);
+	}
+
+	await Promise.all(promises);
+	return locales;
+}
+
+module.exports.getLocales = getLocales;

--- a/super-update.config.json
+++ b/super-update.config.json
@@ -1,5 +1,5 @@
 {
-  "themesRepo": "../Themes",
+  "themesRepo": ".",
   "output": "packages/theme-translations/locales",
   "themePackages": {
     "path": "packages",

--- a/super-update.config.json
+++ b/super-update.config.json
@@ -1,0 +1,38 @@
+{
+  "themesRepo": "../Themes",
+  "output": "packages/theme-translations/locales",
+  "themePackages": {
+    "path": "packages",
+    "exclude": ["_shared", "theme-translations"]
+  },
+  "sharedPartials": "packages/_shared/partials",
+  "externalSources": [
+    {
+      "name": "casper",
+      "repo": "TryGhost/Casper",
+      "ref": "main",
+      "local": null
+    },
+    {
+      "name": "source",
+      "repo": "TryGhost/Source",
+      "ref": "main",
+      "local": null
+    },
+    {
+      "name": "ghost-tpl",
+      "repo": "TryGhost/Ghost",
+      "ref": "main",
+      "path": "ghost/core/core/frontend/helpers/tpl",
+      "local": null
+    },
+    {
+      "name": "ghost-private",
+      "repo": "TryGhost/Ghost",
+      "ref": "main",
+      "path": "ghost/core/core/frontend/apps/private-blogging/lib/views",
+      "files": ["private.hbs"],
+      "local": null
+    }
+  ]
+}


### PR DESCRIPTION
The "super-update" needs to build the xx.json files that live in Themes/packages/theme-translations/locales.  So it'll run within the Themes repo, but needs to pull strings from all of:

- Casper repo (submodule of Ghost)
- Source repo (submodule of Ghost)
- All the themes in Themes/packages (note this doesn't include _shared or theme-translations) (Themes is a separate monorepo, not in the main monorepo.)
- Themes/_shared/partials
- https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
- The .hbs in https://github.com/TryGhost/Ghost/tree/main/ghost/core/core/frontend/helpers/tpl

I don't want to actually wrap strings in super-update, just to consolidate what's already wrapped into the one "source of truth" location, and to keep that location up to date.

It also builds/updates context.json, setting the values for each key to where the strings were found.  (The intent being that a human would later replace it with more useful context, but this is a good start.)
